### PR TITLE
ID-Bindings for Wicket 1.5+

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,12 @@ defaults to `true`.
 defaults to `I18N`.
 * `translation.type` - the file types of the translation files. Can be either
 `xml` or `properties`, defaults to `properties`.
+    * XML files are expected to end with `.properties.xml`, which is the 
+      [default setting since Wicket 1.5](migrationguide). If you need support
+      for the older `.xml` extension check out the previous version.
 * `debug` - if set to `true`, debug messages are logged while processing.
+
+[migrationguide]: https://cwiki.apache.org/WICKET/migration-to-wicket-15.html#MigrationtoWicket1.5-XMLbasedpropertyfiles  "Migrating to Wicket 1.5"
 
 A sane minimal properties file probably looks like this:
 

--- a/src/main/java/de/frickelbude/wicket/TranslationType.java
+++ b/src/main/java/de/frickelbude/wicket/TranslationType.java
@@ -15,18 +15,24 @@
  */
 package de.frickelbude.wicket;
 
-import java.util.Locale;
 
 /**
  * Defines the possible types of wicket translation files.
  * 
  * @author Ole Langbehn (ole.langbehn@googlemail.com) (initial creation)
+ * @author Sebastian Gaul (sgaul@milabent.de)
  */
 public enum TranslationType {
-        XML,
-        PROPERTIES;
+        XML("properties.xml"),
+        PROPERTIES("properties");
+    
+    private final String _extension;
+        
+    private TranslationType(String extension) {
+		_extension = extension;
+	}
 
     public String getExtension() {
-        return name().toLowerCase( Locale.getDefault() );
+        return _extension;
     }
 }


### PR DESCRIPTION
Wicket 1.5 introduced a new default file extension for XML translation
files, which is ".properties.xml" rather than ".xml".
